### PR TITLE
Fix build, TypeScript errors, and arrow hit area UX bug

### DIFF
--- a/frontend/e2e/passage-arrow-visibility.spec.ts
+++ b/frontend/e2e/passage-arrow-visibility.spec.ts
@@ -1,5 +1,9 @@
 import { test, expect } from "@playwright/test";
 
+// Click near the top of the paragraph's first line to avoid the arrow style
+// picker overlay that appears when the arrow tool is activated.
+const FIRST_LINE_Y_OFFSET = 15;
+
 async function drawArrowInEditor(
   page: import("@playwright/test").Page,
   editorIndex: number,
@@ -18,12 +22,12 @@ async function drawArrowInEditor(
   expect(box).not.toBeNull();
 
   // Select and confirm anchor
-  await page.mouse.click(box!.x + anchorXOffset, box!.y + box!.height / 2);
+  await page.mouse.click(box!.x + anchorXOffset, box!.y + FIRST_LINE_Y_OFFSET);
   await expect(page.locator(".word-selection")).toBeVisible({ timeout: 2000 });
   await page.keyboard.press("Enter");
 
   // Select and confirm target
-  await page.mouse.click(box!.x + targetXOffset, box!.y + box!.height / 2);
+  await page.mouse.click(box!.x + targetXOffset, box!.y + FIRST_LINE_Y_OFFSET);
   await expect(page.locator(".word-selection")).toBeVisible({ timeout: 2000 });
   await page.keyboard.press("Enter");
   // Tool auto-switches to selection
@@ -48,7 +52,7 @@ async function drawArrowBetweenEditors(
   expect(srcBox).not.toBeNull();
 
   // Select and confirm anchor
-  await page.mouse.click(srcBox!.x + anchorXOffset, srcBox!.y + srcBox!.height / 2);
+  await page.mouse.click(srcBox!.x + anchorXOffset, srcBox!.y + FIRST_LINE_Y_OFFSET);
   await expect(page.locator(".word-selection")).toBeVisible({ timeout: 2000 });
   await page.keyboard.press("Enter");
 
@@ -61,7 +65,7 @@ async function drawArrowBetweenEditors(
   expect(tgtBox).not.toBeNull();
 
   // Select and confirm target
-  await page.mouse.click(tgtBox!.x + targetXOffset, tgtBox!.y + tgtBox!.height / 2);
+  await page.mouse.click(tgtBox!.x + targetXOffset, tgtBox!.y + FIRST_LINE_Y_OFFSET);
   await expect(page.locator(".word-selection")).toBeVisible({ timeout: 2000 });
   await page.keyboard.press("Enter");
   // Wait for tool to switch back to selection before returning

--- a/frontend/e2e/ui-consistency.spec.ts
+++ b/frontend/e2e/ui-consistency.spec.ts
@@ -546,7 +546,7 @@ test.describe("all elements hidden state", () => {
     await drawArrowInEditor(page, 0);
     // Switch back to comments tool after drawing arrow
     await page.keyboard.press("c");
-    await clickWordInEditor(page, 0, 100);
+    await clickWordInEditor(page, 0, 200);
     await addAnnotation(page, "Will hide");
 
     // Hide the only layer

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -12,6 +12,7 @@ const mockWorkspace = {
     showDrawingToasts: true,
     showCommentsToasts: true,
     showHighlightToasts: true,
+    overscrollEnabled: false,
   },
   annotations: { activeTool: "selection" as const },
   layers: [] as { id: string; color: string; name: string; visible: boolean; arrowStyle: string; highlights: { id: string; editorIndex: number; from: number; to: number; text: string; annotation: string; type: string }[]; arrows: unknown[]; underlines: unknown[] }[],
@@ -119,6 +120,10 @@ beforeEach(() => {
     isLayersOn: false,
     isMultipleRowsLayout: false,
     isLocked: false,
+    showDrawingToasts: true,
+    showCommentsToasts: true,
+    showHighlightToasts: true,
+    overscrollEnabled: false,
   }
   mockWorkspace.layers = []
   mockWorkspace.activeLayerId = null

--- a/frontend/src/components/ArrowOverlay.test.tsx
+++ b/frontend/src/components/ArrowOverlay.test.tsx
@@ -368,7 +368,7 @@ describe("ArrowOverlay", () => {
     expect(polygon?.getAttribute("fill")).toBe(layerColor)
   })
 
-  it("arrow hit areas have pointer-events auto when arrow tool is active", () => {
+  it("arrow hit areas have pointer-events none when arrow tool is active", () => {
     const layer = createLayer({
       arrows: [
         {
@@ -381,6 +381,26 @@ describe("ArrowOverlay", () => {
     render(
       <ArrowOverlay
         {...createDefaultProps({ layers: [layer], activeTool: "arrow" })}
+      />
+    )
+
+    const hitArea = screen.getByTestId("arrow-hit-area")
+    expect(hitArea).toHaveStyle({ pointerEvents: "none" })
+  })
+
+  it("arrow hit areas have pointer-events auto when selection tool is active", () => {
+    const layer = createLayer({
+      arrows: [
+        {
+          id: "a1",
+          from: { editorIndex: 0, from: 1, to: 5, text: "hello" },
+          to: { editorIndex: 1, from: 10, to: 15, text: "world" },
+        },
+      ],
+    })
+    render(
+      <ArrowOverlay
+        {...createDefaultProps({ layers: [layer], activeTool: "selection" })}
       />
     )
 

--- a/frontend/src/components/ArrowOverlay.tsx
+++ b/frontend/src/components/ArrowOverlay.tsx
@@ -57,7 +57,6 @@ export function ArrowOverlay({
   activeTool,
   sectionVisibility,
   isDarkMode,
-  isLocked,
 }: ArrowOverlayProps) {
   const [hoveredArrowId, setHoveredArrowId] = useState<string | null>(null)
   // Structural tick — only for structural changes (layers, visibility, preview), NOT scroll
@@ -622,7 +621,6 @@ export function ArrowOverlay({
 
         {crossEditorArrows.map((data) => {
           const styleAttrs = getArrowStyleAttrs(data.arrowStyle)
-          const isHovered = hoveredArrowId === data.arrowId
           const isSelected = selectedArrow?.arrowId === data.arrowId
           const hideMarker = isSelected
           if (styleAttrs.isDouble) {
@@ -762,7 +760,7 @@ export function ArrowOverlay({
                 strokeWidth={12}
                 fill="none"
                 style={{
-                  pointerEvents: "auto",
+                  pointerEvents: activeTool === "arrow" ? "none" : "auto",
                   cursor: "pointer",
                 }}
                 onMouseEnter={() => setHoveredArrowId(data.arrowId)}

--- a/frontend/src/components/ButtonPane.test.tsx
+++ b/frontend/src/components/ButtonPane.test.tsx
@@ -1,5 +1,5 @@
 import { screen, fireEvent, act } from "@testing-library/react"
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect } from "vitest"
 import { ButtonPane } from "./ButtonPane"
 import { renderWithWorkspace } from "@/test/render-with-workspace"
 

--- a/frontend/src/components/LayerRow.test.tsx
+++ b/frontend/src/components/LayerRow.test.tsx
@@ -30,6 +30,7 @@ function renderRow(overrides = {}) {
     onToggleVisibility: vi.fn(),
     onRemoveHighlight: vi.fn(),
     onRemoveArrow: vi.fn(),
+    onRemoveUnderline: vi.fn(),
   }
   const props = { ...defaults, ...overrides }
   return { ...render(<LayerRow {...props} />), props }

--- a/frontend/src/components/ManagementPane.test.tsx
+++ b/frontend/src/components/ManagementPane.test.tsx
@@ -280,7 +280,7 @@ describe("ManagementPane", () => {
   })
 
   it("passes sectionNames to LayerRow for item display", () => {
-    const { workspace } = renderPane({ layers: [layerWithItems], sectionNames: ["Intro", "Body"] })
+    renderPane({ layers: [layerWithItems], sectionNames: ["Intro", "Body"] })
     fireEvent.click(screen.getByTestId("layerExpand-0"))
     const span = screen.getByText("my note")
     expect(span).toHaveAttribute("title", "my note (Intro)")

--- a/frontend/src/components/SelectionRingOverlay.tsx
+++ b/frontend/src/components/SelectionRingOverlay.tsx
@@ -96,7 +96,7 @@ export function SelectionRingOverlay({
 
     function compute() {
       try {
-        setRects(getSelectionRects(editor, selection, wrapper))
+        setRects(getSelectionRects(editor!, selection!, wrapper!))
       } catch {
         setRects([])
       }

--- a/frontend/src/components/tiptap-templates/simple/simple-editor.test.tsx
+++ b/frontend/src/components/tiptap-templates/simple/simple-editor.test.tsx
@@ -165,6 +165,8 @@ const defaultEditorPaneProps = {
   activeLayerColor: null,
   isDarkMode: false,
   selectedArrowId: null,
+  removeArrow: vi.fn(),
+  sectionVisibility: [true],
 }
 
 beforeEach(() => {

--- a/frontend/src/hooks/use-comment-mode.tsx
+++ b/frontend/src/hooks/use-comment-mode.tsx
@@ -9,10 +9,10 @@ interface UseCommentModeOptions {
   selection: WordSelection | null
   activeLayerId: string | null
   addLayer: () => string
-  layers: { id: string; highlights: { id: string; editorIndex: number; from: number; to: number; annotation: string }[] }[]
+  layers: { id: string; highlights: { id: string; editorIndex: number; from: number; to: number; annotation: string; type: "highlight" | "comment" }[] }[]
   addHighlight: (
     layerId: string,
-    highlight: { editorIndex: number; from: number; to: number; text: string; annotation: string }
+    highlight: { editorIndex: number; from: number; to: number; text: string; annotation: string; type: "highlight" | "comment" }
   ) => string
   removeHighlight: (layerId: string, highlightId: string) => void
   onHighlightAdded?: (layerId: string, highlightId: string) => void

--- a/frontend/src/hooks/use-drawing-mode.test.tsx
+++ b/frontend/src/hooks/use-drawing-mode.test.tsx
@@ -75,7 +75,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, setStatus })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     // Set selection, then confirm
@@ -98,7 +98,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, addArrow, setActiveTool, setStatus })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     // Set selection and confirm anchor
@@ -127,7 +127,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, setActiveTool })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })
@@ -143,7 +143,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, setStatus })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     // Confirm anchor
@@ -167,7 +167,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, activeLayerId: null, addLayer, addArrow })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     // First confirm — should auto-create layer and set anchor
@@ -193,7 +193,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, activeLayerId: null, addLayer })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })
@@ -209,7 +209,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { activeTool: ActiveTool; selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ activeTool: props.activeTool, selection: props.selection, clearStatus })),
-      { initialProps: { activeTool: "arrow" as ActiveTool, selection: null } }
+      { initialProps: { activeTool: "arrow" as ActiveTool, selection: null as WordSelection | null } }
     )
 
     rerender({ activeTool: "arrow", selection: word1 })
@@ -227,7 +227,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { activeTool: ActiveTool; selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ activeTool: props.activeTool, selection: props.selection, clearStatus })),
-      { initialProps: { activeTool: "arrow" as ActiveTool, selection: null } }
+      { initialProps: { activeTool: "arrow" as ActiveTool, selection: null as WordSelection | null } }
     )
 
     // Enter drawing phase so wasActive will be true
@@ -245,7 +245,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { isLocked: boolean; selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ isLocked: props.isLocked, selection: props.selection, clearStatus })),
-      { initialProps: { isLocked: true, selection: null } }
+      { initialProps: { isLocked: true, selection: null as WordSelection | null } }
     )
 
     rerender({ isLocked: true, selection: word1 })
@@ -260,7 +260,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { isLocked: boolean; selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ isLocked: props.isLocked, selection: props.selection })),
-      { initialProps: { isLocked: true, selection: null } }
+      { initialProps: { isLocked: true, selection: null as WordSelection | null } }
     )
 
     rerender({ isLocked: true, selection: word1 })
@@ -276,7 +276,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     // During selecting-anchor phase, selection changes should NOT create a preview
@@ -310,7 +310,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ showDrawingToasts: false, addArrow, selection: props.selection, setStatus })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })
@@ -327,7 +327,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ showDrawingToasts: false, activeLayerId: null, addLayer, selection: props.selection })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })
@@ -338,10 +338,10 @@ describe("useDrawingMode", () => {
   })
 
   it("selection is preserved after confirming anchor", () => {
-    const { result, rerender } = renderHook(
+    const { result } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection })),
-      { initialProps: { selection: word1 } }
+      { initialProps: { selection: word1 as WordSelection | null } }
     )
 
     act(() => { result.current.confirmSelection() })
@@ -357,7 +357,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { activeTool: ActiveTool; selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ activeTool: props.activeTool, selection: props.selection })),
-      { initialProps: { activeTool: "selection" as ActiveTool, selection: word1 } }
+      { initialProps: { activeTool: "selection" as ActiveTool, selection: word1 as WordSelection | null } }
     )
 
     // Switch to arrow tool — selection should not be cleared
@@ -390,7 +390,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, addArrow, activeArrowStyle: "dashed" })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })
@@ -410,7 +410,7 @@ describe("useDrawingMode", () => {
     const { result, rerender } = renderHook(
       (props: { selection: WordSelection | null }) =>
         useDrawingMode(createOptions({ selection: props.selection, addArrow })),
-      { initialProps: { selection: null } }
+      { initialProps: { selection: null as WordSelection | null } }
     )
 
     rerender({ selection: word1 })

--- a/frontend/src/hooks/use-editor-workspace.test.ts
+++ b/frontend/src/hooks/use-editor-workspace.test.ts
@@ -616,6 +616,8 @@ describe("useEditorWorkspace", () => {
         from: 1,
         to: 5,
         text: "hello",
+        annotation: "",
+        type: "highlight" as const,
       })
     })
 
@@ -643,6 +645,8 @@ describe("useEditorWorkspace", () => {
         from: 1,
         to: 5,
         text: "hello",
+        annotation: "",
+        type: "highlight" as const,
       })
     })
 
@@ -665,12 +669,16 @@ describe("useEditorWorkspace", () => {
         from: 1,
         to: 5,
         text: "hello",
+        annotation: "",
+        type: "highlight" as const,
       })
       result.current.addHighlight(layerId, {
         editorIndex: 0,
         from: 10,
         to: 15,
         text: "world",
+        annotation: "",
+        type: "highlight" as const,
       })
     })
 
@@ -701,12 +709,16 @@ describe("useEditorWorkspace", () => {
         from: 1,
         to: 5,
         text: "hello",
+        annotation: "",
+        type: "highlight" as const,
       })
       result.current.addHighlight(layerId, {
         editorIndex: 0,
         from: 10,
         to: 15,
         text: "world",
+        annotation: "",
+        type: "highlight" as const,
       })
     })
 

--- a/frontend/src/hooks/use-editor-workspace.ts
+++ b/frontend/src/hooks/use-editor-workspace.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from "react"
+import { useState, useCallback, useRef } from "react"
 import { useSettings } from "./use-settings"
 import { useLayers } from "./use-layers"
 import { useEditors } from "./use-editors"

--- a/frontend/src/hooks/use-highlight-mode.test.tsx
+++ b/frontend/src/hooks/use-highlight-mode.test.tsx
@@ -21,7 +21,6 @@ function createOptions(overrides: Record<string, unknown> = {}) {
 }
 
 const word1: WordSelection = { editorIndex: 0, from: 1, to: 5, text: "hello" }
-const word2: WordSelection = { editorIndex: 0, from: 10, to: 15, text: "world" }
 
 describe("useHighlightMode", () => {
   beforeEach(() => {

--- a/frontend/src/hooks/use-highlight-mode.tsx
+++ b/frontend/src/hooks/use-highlight-mode.tsx
@@ -9,10 +9,10 @@ interface UseHighlightModeOptions {
   selection: WordSelection | null
   activeLayerId: string | null
   addLayer: () => string
-  layers: { id: string; highlights: { id: string; editorIndex: number; from: number; to: number; annotation: string }[] }[]
+  layers: { id: string; highlights: { id: string; editorIndex: number; from: number; to: number; annotation: string; type: "highlight" | "comment" }[] }[]
   addHighlight: (
     layerId: string,
-    highlight: { editorIndex: number; from: number; to: number; text: string; annotation: string }
+    highlight: { editorIndex: number; from: number; to: number; text: string; annotation: string; type: "highlight" | "comment" }
   ) => string
   removeHighlight: (layerId: string, highlightId: string) => void
   showHighlightToasts: boolean

--- a/frontend/src/hooks/use-layers.test.ts
+++ b/frontend/src/hooks/use-layers.test.ts
@@ -341,7 +341,7 @@ describe("useLayers", () => {
     const { result } = renderHook(() => useLayers())
 
     let ret: { id: string; name: string } = { id: "", name: "" }
-    act(() => { ret = result.current.addLayer() })
+    act(() => { ret = result.current.addLayer() as { id: string; name: string } })
 
     expect(ret.id).toBe(result.current.layers[0].id)
     expect(ret.name).toBe("Layer 1")

--- a/frontend/src/hooks/use-similar-text-highlight.test.ts
+++ b/frontend/src/hooks/use-similar-text-highlight.test.ts
@@ -12,8 +12,8 @@ vi.mock("@tiptap/pm/view", async () => {
   return {
     ...actual,
     DecorationSet: {
-      ...actual.DecorationSet,
-      empty: actual.DecorationSet.empty,
+      ...(actual as any).DecorationSet,
+      empty: (actual as any).DecorationSet.empty,
       create: vi.fn((_doc: unknown, decorations: unknown[]) => {
         capturedDecorations = decorations
         return { __decorationCount: decorations.length }

--- a/frontend/src/hooks/use-underline-mode.test.tsx
+++ b/frontend/src/hooks/use-underline-mode.test.tsx
@@ -21,7 +21,6 @@ function createOptions(overrides: Record<string, unknown> = {}) {
 }
 
 const word1: WordSelection = { editorIndex: 0, from: 1, to: 5, text: "hello" }
-const word2: WordSelection = { editorIndex: 0, from: 10, to: 15, text: "world" }
 
 describe("useUnderlineMode", () => {
   beforeEach(() => {

--- a/frontend/src/hooks/use-unified-decorations.test.ts
+++ b/frontend/src/hooks/use-unified-decorations.test.ts
@@ -13,8 +13,8 @@ vi.mock("@tiptap/pm/view", async () => {
   return {
     ...actual,
     DecorationSet: {
-      ...actual.DecorationSet,
-      empty: actual.DecorationSet.empty,
+      ...(actual as any).DecorationSet,
+      empty: (actual as any).DecorationSet.empty,
       create: vi.fn((_doc: unknown, decorations: unknown[]) => {
         capturedDecorations = decorations
         return { __decorationCount: decorations.length }
@@ -49,6 +49,7 @@ function createLayer(overrides: Partial<Layer> = {}): Layer {
     visible: true,
     highlights: [],
     arrows: [],
+    underlines: [],
     ...overrides,
   }
 }

--- a/frontend/src/lib/tiptap/extensions/arrow-lines-plugin.ts
+++ b/frontend/src/lib/tiptap/extensions/arrow-lines-plugin.ts
@@ -1,5 +1,5 @@
 import { Extension } from "@tiptap/core"
-import { Plugin, PluginKey } from "@tiptap/pm/state"
+import { Plugin, PluginKey, type EditorState } from "@tiptap/pm/state"
 import type { EditorView } from "@tiptap/pm/view"
 import type { ArrowEndpoint, ArrowStyle } from "@/types/editor"
 import { getWordCenterContentRelative } from "@/lib/tiptap/nearest-word"
@@ -37,7 +37,6 @@ export class ArrowLinesView {
   private wrapper: HTMLElement | null = null
   private view: EditorView
   private arrows: ArrowData[] = []
-  private isDarkMode = false
   private hoveredArrowId: string | null = null
   private selectedArrowId: string | null = null
   private resizeObserver: ResizeObserver | null = null
@@ -81,7 +80,7 @@ export class ArrowLinesView {
     this.visualSvg.style.height = `${this.wrapper.scrollHeight}px`
   }
 
-  update(view: EditorView, prevState: { doc: { eq: (doc: unknown) => boolean } }) {
+  update(view: EditorView, prevState: EditorState) {
     this.view = view
     viewInstances.set(view, this)
     this.ensureWrapper()
@@ -98,7 +97,6 @@ export class ArrowLinesView {
   }
 
   setDarkMode(isDarkMode: boolean) {
-    this.isDarkMode = isDarkMode
     this.ensureWrapper()
     this.visualSvg.style.mixBlendMode = isDarkMode ? "screen" : "multiply"
     this.redraw()

--- a/frontend/src/lib/tiptap/word-boundaries.test.ts
+++ b/frontend/src/lib/tiptap/word-boundaries.test.ts
@@ -33,43 +33,43 @@ function makeMockDocNonTextblock() {
 describe("getWordBoundaries", () => {
   it("returns word boundaries for a position inside a word", () => {
     const doc = makeMockDoc("hello world")
-    const result = getWordBoundaries(doc, 3) // offset 2 -> inside "hello"
+    const result = getWordBoundaries(doc as any, 3) // offset 2 -> inside "hello"
     expect(result).toEqual({ from: 1, to: 6, text: "hello" })
   })
 
   it("returns word at start of text", () => {
     const doc = makeMockDoc("hello world")
-    const result = getWordBoundaries(doc, 1) // offset 0 -> start of "hello"
+    const result = getWordBoundaries(doc as any, 1) // offset 0 -> start of "hello"
     expect(result).toEqual({ from: 1, to: 6, text: "hello" })
   })
 
   it("returns second word", () => {
     const doc = makeMockDoc("hello world")
-    const result = getWordBoundaries(doc, 8) // offset 7 -> inside "world"
+    const result = getWordBoundaries(doc as any, 8) // offset 7 -> inside "world"
     expect(result).toEqual({ from: 7, to: 12, text: "world" })
   })
 
   it("returns null for non-textblock parent", () => {
     const doc = makeMockDocNonTextblock()
-    expect(getWordBoundaries(doc, 1)).toBeNull()
+    expect(getWordBoundaries(doc as any, 1)).toBeNull()
   })
 
   it("returns adjacent word when position is at a space boundary", () => {
     const doc = makeMockDoc("hello world")
     // offset 5 is the space — backward walk finds "hello"
-    const result = getWordBoundaries(doc, 6)
+    const result = getWordBoundaries(doc as any, 6)
     expect(result).toEqual({ from: 1, to: 6, text: "hello" })
   })
 
   it("includes apostrophes in word boundaries", () => {
     const doc = makeMockDoc("don't stop")
-    const result = getWordBoundaries(doc, 3) // inside "don't"
+    const result = getWordBoundaries(doc as any, 3) // inside "don't"
     expect(result).toEqual({ from: 1, to: 6, text: "don't" })
   })
 
   it("includes hyphens in word boundaries", () => {
     const doc = makeMockDoc("well-known")
-    const result = getWordBoundaries(doc, 4) // inside "well-known"
+    const result = getWordBoundaries(doc as any, 4) // inside "well-known"
     expect(result).toEqual({ from: 1, to: 11, text: "well-known" })
   })
 
@@ -83,6 +83,6 @@ describe("getWordBoundaries", () => {
         }
       },
     }
-    expect(getWordBoundaries(doc, 0)).toBeNull()
+    expect(getWordBoundaries(doc as any, 0)).toBeNull()
   })
 })

--- a/frontend/src/lib/ws-protocol.ts
+++ b/frontend/src/lib/ws-protocol.ts
@@ -29,6 +29,7 @@ export interface LayerPayload {
   visible: boolean
   highlights: HighlightPayload[]
   arrows: ArrowPayload[]
+  underlines?: Array<Record<string, unknown>>
 }
 
 export interface EditorPayload {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite"
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: "/",
+  base: "/referencer/",
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {


### PR DESCRIPTION
## Summary
- Set Vite base path to `/referencer/` for GitHub Pages project site deployment
- Fix ~68 TypeScript compilation errors across hooks, components, and tests (type signature mismatches, missing props, unused variables, null checks)
- Fix UX bug where arrow hit areas intercepted word clicks during drawing mode — now disables `pointer-events` on existing arrow hit areas when the arrow tool is active
- Fix e2e tests: adjust click positions to avoid arrow style picker overlay and arrow hit area collisions in multi-editor layouts

## Test plan
- [x] `tsc -b` compiles with zero errors
- [x] `bun run build` succeeds (tsc + vite build)
- [x] 920 unit tests pass (`bun run test:run`)
- [x] 133 e2e tests pass (`bun run test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)