### PR TITLE
Add Pages Functions proxy middleware

### DIFF
--- a/frontend/functions/_middleware.ts
+++ b/frontend/functions/_middleware.ts
@@ -1,0 +1,27 @@
+/**
+ * Cloudflare Pages middleware that proxies API requests to the backend worker.
+ * Routes are gated by _routes.json so this only runs for /auth/*, /api/*, /s/*.
+ * Cookies stay same-origin (pages.dev) — no third-party cookie issues.
+ */
+
+const WORKER_URL = "https://referencer-api.elurion.workers.dev";
+
+export const onRequest: PagesFunction = async (context) => {
+  const url = new URL(context.request.url);
+  const target = new URL(url.pathname + url.search, WORKER_URL);
+
+  const headers = new Headers(context.request.headers);
+  headers.set("host", target.host);
+
+  const init: RequestInit = {
+    method: context.request.method,
+    headers,
+    redirect: "manual",
+  };
+
+  if (context.request.method !== "GET" && context.request.method !== "HEAD") {
+    init.body = context.request.body;
+  }
+
+  return fetch(target.toString(), init);
+};

--- a/frontend/public/_routes.json
+++ b/frontend/public/_routes.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "include": ["/auth/*", "/api/*", "/s/*"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary
- Add `_middleware.ts` that proxies `/auth/*`, `/api/*`, and `/s/*` from Cloudflare Pages to the backend worker
- Add `_routes.json` to gate which routes hit the middleware
- Keeps cookies same-origin (pages.dev) — no third-party cookie issues

## Test plan
- [x] Deployed to Pages and verified proxy works
- [ ] Update Google/GitHub OAuth redirect URIs to `referencer.pages.dev` callbacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)