### PR TITLE
Fix PDF upload: create storage bucket and allow Supabase in CSP

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com; connect-src 'self' wss:; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self';"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com; connect-src 'self' wss: https://*.supabase.co; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self'; form-action 'self';"
     />
     <title>referencer</title>
   </head>

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -271,3 +271,8 @@ ALTER TABLE share_link ENABLE ROW LEVEL SECURITY;
 ALTER TABLE yjs_document ENABLE ROW LEVEL SECURITY;
 ALTER TABLE annotation_index ENABLE ROW LEVEL SECURITY;
 ALTER TABLE document_tag ENABLE ROW LEVEL SECURITY;
+
+-- Storage bucket for uploaded PDFs (private — accessed via signed URLs).
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('document-pdfs', 'document-pdfs', false)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
The document-pdfs bucket was never created, causing 500 on upload. Added bucket creation to schema.sql and allowed *.supabase.co in the frontend CSP connect-src so signed PDF URLs can be fetched.